### PR TITLE
Add localforagedown

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,6 +8,7 @@
 | **Chiguireitor**       | [**@chiguireitor**](https://github.com/chiguireitor)   |                                                            |
 | **Cody Eilar**         |                                                        |                                                            |
 | **Evan Schwartz**      | [**@emschwartz**](https://github.com/emschwartz)       |                                                            |
+| **Gio Palacino**       | [**@GioCirque**](https://github.com/GioCirque)         |                                                            |
 | **Huan LI**            | [**@zixia**](https://github.com/zixia)                 | [**@zixia@twitter**](https://twitter.com/zixia)            |
 | **Loune Lam**          | [**@loune**](https://github.com/loune)                 |                                                            |
 | **Matthew Wright**     | [**@farskipper**](https://github.com/farskipper)       |                                                            |

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Name | Compatibility | Dependencies | Type
 **[`s3leveldown`][s3leveldown]** | ![abstract-leveldown](https://img.shields.io/badge/abstract--leveldown-6.0-yellow.svg) | [![dependencies](https://img.shields.io/david/loune/s3leveldown.svg?label=%E2%99%A5)](https://david-dm.org/loune/s3leveldown) | [AWS S3](https://aws.amazon.com/s3/)
 **[`gaiadown-ts`][gaiadown-ts]** | ![abstract-leveldown](https://img.shields.io/badge/abstract--leveldown-6.0-yellow.svg) | [![dependencies](https://img.shields.io/david/acidleroy/gaiadown-ts.svg?label=%E2%99%A5)](https://david-dm.org/acidleroy/gaiadown-ts) | [Gaia](https://github.com/blockstack/gaia)
 **[`dynamodb-leveldown`][dynamodb-leveldown]** | ![abstract-leveldown](https://img.shields.io/badge/abstract--leveldown-6.2-brightgreen.svg) | [![dependencies](https://img.shields.io/david/GioCirque/DynamoDb-LevelDown.svg?label=%E2%99%A5)](https://david-dm.org/GioCirque/DynamoDb-LevelDown) | [AWS DynamoDB](http://aws.amazon.com/dynamodb/)
+**[`localforagedown`][localforagedown]** | ![abstract-leveldown](https://img.shields.io/badge/abstract--leveldown-6.2-brightgreen.svg) | [![dependencies](https://img.shields.io/david/KsRyY/localforagedown.svg?label=%E2%99%A5)](https://david-dm.org/KsRyY/localforagedown) | [localForage](https://github.com/localForage/localForage/)
 
 ## Layers
 
@@ -1092,6 +1093,8 @@ To sustain [`Level`](https://github.com/Level) and its activities, become a back
 [lmdb-leveldown]: https://github.com/chrbala/lmdb-leveldown
 
 [localdown]: https://github.com/bhoriuchi/localdown
+
+[localforagedown]: https://github.com/KsRyY/localforagedown
 
 [localstorage-down]: https://github.com/No9/localstorage-down
 

--- a/modules/stores.json
+++ b/modules/stores.json
@@ -125,6 +125,10 @@
       "type": "[AWS DynamoDB](http://aws.amazon.com/dynamodb/)",
       "copyrightYear": 2019,
       "author": "Gio Palacino"
+    },
+    "localforagedown": {
+      "github": "KsRyY/localforagedown",
+      "type": "[localForage](https://github.com/localForage/localForage/)"
     }
   }
 }


### PR DESCRIPTION
`localforagedown` is a abstract-leveldown compliant store created by me. It uses localForage as it storage backend (which uses following driver in sequence: `IndexedDB`, `WebSQL`, `localStorage`)